### PR TITLE
Bump version: 0.0.1 → 0.0.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,6 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.0.2
 files = setup.py
 commit = True
 tag = True
+

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = open('README.rst').read()
 
 setup_params = dict(
     name='voluptuary',
-    version='0.0.1',
+    version='0.0.2',
     license='MIT',
     author='Paul Glass',
     author_email='pnglass@gmail.com',


### PR DESCRIPTION
- Releasing README correction to indicate only Python 3 support